### PR TITLE
Add symlinks for pirate ships

### DIFF
--- a/Ship_bound_for_Mhaura_Pirates.obj
+++ b/Ship_bound_for_Mhaura_Pirates.obj
@@ -1,0 +1,1 @@
+Ship_bound_for_Mhaura.obj

--- a/Ship_bound_for_Selbina_Pirates.obj
+++ b/Ship_bound_for_Selbina_Pirates.obj
@@ -1,0 +1,1 @@
+Ship_bound_for_Selbina.obj


### PR DESCRIPTION
Pirate ship zone names are suffixed with `_Pirates` (and are different zone IDs), but they seem to share the same zone model. Adding symbolic links to the non-pirate versions with this PR, such that the game server can reuse the meshes to for the pirate zones.